### PR TITLE
std::swap should not throw for C++11 (PR #1171)

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -262,7 +262,7 @@ NAMESPACE_END
 
 #ifndef __BORLANDC__
 NAMESPACE_BEGIN(std)
-template<> inline void swap(CryptoPP::ByteQueue &a, CryptoPP::ByteQueue &b)
+template<> inline void swap(CryptoPP::ByteQueue &a, CryptoPP::ByteQueue &b) CRYPTOPP_NO_THROW
 {
 	a.swap(b);
 }


### PR DESCRIPTION
Add noexcept decoration to std::swap for C++11 and above.